### PR TITLE
Add netstat alternative

### DIFF
--- a/postenum.sh
+++ b/postenum.sh
@@ -588,7 +588,10 @@ function CommAndNet(){
 		echo $yellowintensy"[x] Display all TCP/UDP connected socket, PID/program:"$white
 		echo -e "$NETSTAT\n"
 	else
-		:
+		#alternative to netstat
+		SS=$(ss -tuln 2>/dev/null)
+		echo $yellowintensy"[x] Display all TCP/UDP connected socket, PID/program:"$white
+		echo -e "$SS\n"
 	fi
 
 	LSOF=$(lsof -Pi 2>/dev/null)


### PR DESCRIPTION
In case netstat is not available, we can use SS command.